### PR TITLE
Typo in excercice 4 step 7

### DIFF
--- a/Hands-on lab/HOL step-by-step - Enterprise-class networking in Azure.md
+++ b/Hands-on lab/HOL step-by-step - Enterprise-class networking in Azure.md
@@ -468,7 +468,7 @@ In this task, you will provision the CloudShop application using an ARM template
 
     ![In the Edit template blade, Load file is selected.](images/Hands-onlabstep-by-step-Enterprise-classnetworkinginAzureimages/media/image58.png "Edit template blade")
 
-7.  Update the following parameters to reference the **WGVNet2** virtual network in the **WGBNetRG2** resource group.
+7.  Update the following parameters to reference the **WGVNet2** virtual network in the **WGVNetRG2** resource group.
 
     ![A screenshot that shows the Existing Virtual Network Name and Existing Virtual Network Resource group parameters.](images/Hands-onlabstep-by-step-Enterprise-classnetworkinginAzureimages/media/image59.png "Template parameters")
 


### PR DESCRIPTION
In all the document the resource group WGVNetRG2 is mentioned as it is except one point where has a typo and it is mentioned as WGBNetRG2. If you copy and paste you will obtain an error in this deploy of the exercise 4.

This commit corrects it.